### PR TITLE
Add CSS rule to make blank square transparent in DarkMode

### DIFF
--- a/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
+++ b/packages/twenty-front/src/modules/ui/utilities/scroll/components/ScrollWrapper.tsx
@@ -21,6 +21,10 @@ const StyledScrollWrapper = styled.div`
   .os-scrollbar-handle {
     background-color: ${({ theme }) => theme.border.color.medium};
   }
+
+  .os-scrollbar-corner {
+    background-color: ${({ theme }) => theme.background.transparent.lighter};
+  }
 `;
 
 export type ScrollWrapperProps = {


### PR DESCRIPTION
* Add `.os-scrollbar-corner` CSS rule to set background color to transparent in DarkMode
* Ensure the CSS rule targets the bottom right corner